### PR TITLE
Add Docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:bookworm
+
+WORKDIR /
+
+# Prep dependencies
+RUN apt-get update && \
+	apt-get install -y openssl wget libicu-dev
+
+# Not the prettiest .NET installation, but it will do
+RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && \
+	chmod +x ./dotnet-install.sh && \
+	./dotnet-install.sh --channel 7.0 --install-dir /usr/local/bin && \
+	rm -v ./dotnet-install.sh
+
+# Build Librum
+RUN mkdir -v /librum
+COPY . /librum
+WORKDIR /librum
+RUN dotnet restore && \
+	cd src/Presentation && \
+	dotnet publish -c Release -o build --no-restore --verbosity m
+
+# Install Librum
+RUN groupadd -r -f librum-server && \
+	useradd -r -g librum-server -d /var/lib/librum-server -m --shell /usr/sbin/nologin librum-server && \
+	mkdir -pv /var/lib/librum-server/srv && \
+	cp -r src/Presentation/build/* /var/lib/librum-server/srv/ && \
+	chmod -R 660 /var/lib/librum-server/srv/* && \
+	install ./self-hosting/run.sh -m770 /var/lib/librum-server/srv
+
+# Copy appsettings to image
+COPY ./docker/appsettings.json /var/lib/librum-server/srv/appsettings.json
+
+# Ensure librum-server userhome ownership is set properly
+RUN chown -R librum-server:librum-server /var/lib/librum-server/
+
+# Cleanup
+RUN rm -rf /librum && \
+	apt-get clean autoclean
+
+USER librum-server
+WORKDIR /var/lib/librum-server/srv
+ENTRYPOINT /var/lib/librum-server/srv/run.sh

--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ The server is written in C# using ASP.NET Core. The codebase can be developed, b
 <br>
 
 # Self-hosting
-
 Librum-Server can easily be self-hosted. This way all your data and books remain on your own devices and are not synchronized to the official cloud.<br>
 You can find the instructions on how to self-host Librum-Server [here](self-hosting/self-host-installation.md).
 
+## Docker
+Before deploying the containers you may wish to update the login credentials defined as environment variables in `docker-compose.yml` and to configure a volume for both the database and Librum-server. Volumes are already included for convenience but disabled by default.
+
+Navigate to the root of the project and run the following command to build and launch a Librum-server instance;
+```shell
+docker compose up -d
+```
+Once running you should have a Librum-server instance running and accessible on `127.0.0.1:5000`.
 
 <br>
 
@@ -17,4 +24,4 @@ You can find the instructions on how to self-host Librum-Server [here](self-host
 Feel free to reach out to us via email (contact@librumreader.com) or discord (m_david#0631) if you are interested in contributing.<br>
 <br>
 We are following a pull request workflow where every contribution is sent as a pull request and merged into the dev/develop branch for testing.
-Please make sure to keep to the conventions used throughout the application and ensure that all tests pass, before submitting any pull request. 
+Please make sure to keep to the conventions used throughout the application and ensure that all tests pass, before submitting any pull request.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+services:
+  librum_server:
+    build: .
+    restart: unless-stopped
+    ports:
+      - 5000:5000
+    environment:
+      JWTValidIssuer: 'exampleIssuer'
+      JWTKey: 'exampleOfALongSecretToken'
+      AdminEmail: 'admin@example.com'
+      AdminPassword: 'strongPassword123'
+      DBConnectionString: 'Server=librum_db;port=3306;Database=librum;Uid=mysql_user;Pwd=mysql_password;'
+      SMTPEndpoint: 'smtp.example.com'
+      SMTPUsername: 'mailuser123'
+      SMTPPassword: 'smtpUserPassword123'
+      SMTPMailFrom: 'mailuser123@example.com'
+      CleanUrl: 'http://0.0.0.0'
+      OpenAIToken: ''
+      DOTNET_PRINT_TELEMETRY_MESSAGE: false
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+      ASPNETCORE_ENVIRONMENT: 'production'
+      LIBRUM_SELFHOSTED: true
+#    volumes:
+#      - librum_server:/var/librum-server/data_storage
+    depends_on:
+        - librum_db
+    networks:
+      - librum
+
+  librum_db:
+    image: mariadb:latest
+    restart: unless-stopped
+    hostname: librum_db
+    environment:
+      MARIADB_USER: 'mysql_user'
+      MARIADB_PASSWORD: 'mysql_password'
+      MARIADB_ROOT_PASSWORD: 'mysql_root_password'
+      MARIADB_DATABASE: 'librum'
+#    volumes:
+#      - librum_db:/var/lib/mysql:Z
+    networks:
+      - librum
+
+networks:
+  librum:
+
+#volumes:
+#  librum_server:
+#  librum_db:

--- a/docker/appsettings.json
+++ b/docker/appsettings.json
@@ -1,0 +1,31 @@
+{
+  "Kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://0.0.0.0:5000"
+      }
+    }
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "AzureKeyVaultUri": "https://librum-keyvault.vault.azure.net/",
+  "IpRateLimiting": {
+    "EnableEndpointRateLimiting": true,
+    "StackBlockedRequests": false,
+    "RealIpHeader": "X-Real-IP",
+    "ClientIdHeader": "X-ClientId",
+    "HttpStatusCode": 429,
+    "GeneralRules": [
+      {
+        "Endpoint": "post:/api/register",
+        "Period": "15m",
+        "Limit": 6
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This will add all files required to run Librum inside of a docker container.

~~There is one bug remaining, librum-server is not able to resolve the `librum_db` hostname as defined in `DBConnectionString`. I am unsure if this is a bug in librum-server or if I am just overlooking something. Manually defining the IP instead of a hostname does make it able to connect with the db. Or maybe it is just a bug on my system..~~ -- It was a bug on my system

Fixes #9 