### PR TITLE
Create docker.yml workflow for automated image building

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: write
+
+jobs:
+  build_and_push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    strategy:
+      # Prevent a failure in one image from stopping the other builds
+      fail-fast: false
+      matrix:
+        include:
+          - context: "."
+            file: "Dockerfile"
+            image: "librum-server"
+            # ARM not working. Needs further research.
+            # platforms: "linux/arm64,linux/amd64"
+            platforms: "linux/amd64"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+        # Workaround to fix error:
+        # failed to push: failed to copy: io: read/write on closed pipe
+        # See https://github.com/docker/build-push-action/issues/761
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        # Skip when PR from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate docker image tags
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=true
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/${{matrix.image}}
+          tags: |
+            # Tag with branch name
+            type=ref,event=branch
+            # Tag with pr-number
+            type=ref,event=pr
+            # Tag with git tag on release
+            type=ref,event=tag
+            type=raw,value=release,enable=${{ github.event_name == 'release' }}
+
+      - name: Determine build cache output
+        id: cache-target
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Essentially just ignore the cache output (PR can't write to registry cache)
+            echo "cache-to=type=local,dest=/tmp/discard,ignore-error=true" >> $GITHUB_OUTPUT
+          else
+            echo "cache-to=type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/librum-build-cache:${{ matrix.image }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          platforms: ${{ matrix.platforms }}
+          # Skip pushing when PR from a fork
+          push: ${{ !github.event.pull_request.head.repo.fork }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/librum-build-cache:${{matrix.image}}
+          cache-to: ${{ steps.cache-target.outputs.cache-to }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
I'm trying to eliminate friction points for people that want to try selfhosting Librum.
This is a basic workflow that builds a `librum-server` image and offers tags such as `:latest`. 
The image is pushed to `ghcr.io`. No extra credentials needed, the package becomes a part of the repo.

The `docker-compose.yml` needs to be updated with the new image:

```yml
version: "3.8"
services:
  librum:
    image: ghcr.io/Librum-Reader/librum-server:latest
    hostname: librum
    container_name: librum
```

The `README.md` needs to be updated with shorter instructions:

# Running with Docker

Librum-Server can be run with Docker. 

```bash
git clone https://github.com/Librum-Reader/Librum-Server
cd Librum-Server
docker compose up -d
```