### PR TITLE
Only add the GitAccessToken to the http request if we have one

### DIFF
--- a/src/Presentation/Controllers/AppInfoController.cs
+++ b/src/Presentation/Controllers/AppInfoController.cs
@@ -41,8 +41,13 @@ public class AppInfoController : ControllerBase
         httpClient.DefaultRequestHeaders.TryAddWithoutValidation(
             "User-Agent",
             "Librum/1.0.0");
-        httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", _configuration["GitAccessToken"]);
+        
+        string accessToken = _configuration["GitAccessToken"];
+        if (!string.IsNullOrWhiteSpace(accessToken))
+        {
+            httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", accessToken);
+        }
 
         var response = await httpClient.GetAsync(url);
         if (response.IsSuccessStatusCode)


### PR DESCRIPTION
For self hosted environments that run without the GitAccessToken the appinfo/latest-version endpoint fails as the provided bearer token is not present. Not setting the header at all allows the call to function as intended.