### PR TITLE
fix database migration for selfhosted instances

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       - MARIADB_DATABASE=librum
       - MARIADB_ROOT_PASSWORD=mariadb
     restart: unless-stopped
+    ports:
+      - 3306:3306
     healthcheck:                              # Ensures the DB is up before the server.
       test: ["CMD", "mariadb-admin", "ping", "-u", "librum", "-p'mariadb'", "-h", "localhost"]
       interval: 20s

--- a/src/Infrastructure/Persistence/DataContext.cs
+++ b/src/Infrastructure/Persistence/DataContext.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Domain.Entities;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Infrastructure.Persistence;
 
@@ -33,6 +34,13 @@ public class DataContext : IdentityDbContext<User>
             .WithOne(pf => pf.Product)
             .HasForeignKey(pf => pf.ProductId)
             .IsRequired();
+
+        builder
+            .Entity<Folder>()
+            .Property(f => f.Description)
+            .HasColumnType(this.Database.ProviderName == "Pomelo.EntityFrameworkCore.MySql"
+                ? "longtext"
+                : "nvarchar(max)");
         
         base.OnModelCreating(builder);
     }


### PR DESCRIPTION
MySQL/MariaDB instances of the database created via `context.Database.EnsureCreated()` fail due to row/page size constraints intercept the entity creation and if database is MySQL, override datatype to `longtext` resolving the page size issue

also seed the selfhosted instance witha dummy self hosted product and assign it to the admin user, allowing first time login